### PR TITLE
Allow saving of records on backend and API

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,7 @@ class ApplicationController < ActionController::Base
   before_action :set_request
 
   def set_request
-    $admin = request.path.include? "/admin"
-    $api = request.path.include? "/api"
+    $token = request.cookies["guest_token"]
   end
 
 end

--- a/app/models/spree/base_decorator.rb
+++ b/app/models/spree/base_decorator.rb
@@ -1,8 +1,21 @@
 Spree::Base.class_eval do
-  validate :check_if_allowed
+  before_create :set_token
+  before_update :verify_token
+  before_destroy :verify_token
+  default_scope { where("#{table_name}.sample_indicator_id = ? OR #{table_name}.sample_indicator_id IS null", $token) }
 
-  def check_if_allowed
-    errors.add(:records, "can't be adjusted on the sample admin") if $admin || $api
+  def set_token
+    self.sample_indicator_id = $token
+  end
+
+  def verify_token
+    raise_sample_error unless sample_indicator_id?
+  end
+
+  private
+
+  def raise_sample_error
+    raise("You can't edit pre-existing items - try creating a new one!")
   end
 
 end

--- a/db/migrate/20200529174800_add_sample_indicator_id_to_everything.rb
+++ b/db/migrate/20200529174800_add_sample_indicator_id_to_everything.rb
@@ -1,0 +1,8 @@
+class AddSampleIndicatorIdToEverything < ActiveRecord::Migration[5.2]
+  def change
+    tables = ActiveRecord::Base.connection.tables - ["schema_migrations"]
+      tables.each do |table|
+        add_column table, :sample_indicator_id, :string
+      end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_14_092732) do
+ActiveRecord::Schema.define(version: 2020_05_29_174800) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
+    t.string "sample_indicator_id"
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -30,23 +34,25 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
     t.datetime "created_at", null: false
+    t.string "sample_indicator_id"
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "friendly_id_slugs", force: :cascade do |t|
+  create_table "friendly_id_slugs", id: :serial, force: :cascade do |t|
     t.string "slug", null: false
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 50
     t.string "scope"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
     t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
     t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
     t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
   end
 
-  create_table "spree_addresses", force: :cascade do |t|
+  create_table "spree_addresses", id: :serial, force: :cascade do |t|
     t.string "firstname"
     t.string "lastname"
     t.string "address1"
@@ -61,23 +67,25 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.integer "country_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["country_id"], name: "index_spree_addresses_on_country_id"
     t.index ["firstname"], name: "index_addresses_on_firstname"
     t.index ["lastname"], name: "index_addresses_on_lastname"
     t.index ["state_id"], name: "index_spree_addresses_on_state_id"
   end
 
-  create_table "spree_adjustment_reasons", force: :cascade do |t|
+  create_table "spree_adjustment_reasons", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "code"
     t.boolean "active", default: true
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["active"], name: "index_spree_adjustment_reasons_on_active"
     t.index ["code"], name: "index_spree_adjustment_reasons_on_code"
   end
 
-  create_table "spree_adjustments", force: :cascade do |t|
+  create_table "spree_adjustments", id: :serial, force: :cascade do |t|
     t.string "source_type"
     t.integer "source_id"
     t.string "adjustable_type"
@@ -92,6 +100,7 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.integer "promotion_code_id"
     t.integer "adjustment_reason_id"
     t.boolean "finalized", default: false, null: false
+    t.string "sample_indicator_id"
     t.index ["adjustable_id", "adjustable_type"], name: "index_spree_adjustments_on_adjustable_id_and_adjustable_type"
     t.index ["adjustable_id"], name: "index_adjustments_on_order_id"
     t.index ["eligible"], name: "index_spree_adjustments_on_eligible"
@@ -100,7 +109,7 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.index ["source_id", "source_type"], name: "index_spree_adjustments_on_source_id_and_source_type"
   end
 
-  create_table "spree_assets", force: :cascade do |t|
+  create_table "spree_assets", id: :serial, force: :cascade do |t|
     t.string "viewable_type"
     t.integer "viewable_id"
     t.integer "attachment_width"
@@ -114,22 +123,24 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.text "alt"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["viewable_id"], name: "index_assets_on_viewable_id"
     t.index ["viewable_type", "type"], name: "index_assets_on_viewable_type_and_type"
   end
 
-  create_table "spree_calculators", force: :cascade do |t|
+  create_table "spree_calculators", id: :serial, force: :cascade do |t|
     t.string "type"
     t.string "calculable_type"
     t.integer "calculable_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.text "preferences"
+    t.string "sample_indicator_id"
     t.index ["calculable_id", "calculable_type"], name: "index_spree_calculators_on_calculable_id_and_calculable_type"
     t.index ["id", "type"], name: "index_spree_calculators_on_id_and_type"
   end
 
-  create_table "spree_cartons", force: :cascade do |t|
+  create_table "spree_cartons", id: :serial, force: :cascade do |t|
     t.string "number"
     t.string "external_number"
     t.integer "stock_location_id"
@@ -140,13 +151,14 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.integer "imported_from_shipment_id"
+    t.string "sample_indicator_id"
     t.index ["external_number"], name: "index_spree_cartons_on_external_number"
     t.index ["imported_from_shipment_id"], name: "index_spree_cartons_on_imported_from_shipment_id", unique: true
     t.index ["number"], name: "index_spree_cartons_on_number", unique: true
     t.index ["stock_location_id"], name: "index_spree_cartons_on_stock_location_id"
   end
 
-  create_table "spree_countries", force: :cascade do |t|
+  create_table "spree_countries", id: :serial, force: :cascade do |t|
     t.string "iso_name"
     t.string "iso"
     t.string "iso3"
@@ -155,10 +167,11 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.boolean "states_required", default: false
     t.datetime "updated_at", precision: 6
     t.datetime "created_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["iso"], name: "index_spree_countries_on_iso"
   end
 
-  create_table "spree_credit_cards", force: :cascade do |t|
+  create_table "spree_credit_cards", id: :serial, force: :cascade do |t|
     t.string "month"
     t.string "year"
     t.string "cc_type"
@@ -172,18 +185,20 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.integer "payment_method_id"
     t.boolean "default", default: false, null: false
     t.integer "address_id"
+    t.string "sample_indicator_id"
     t.index ["payment_method_id"], name: "index_spree_credit_cards_on_payment_method_id"
     t.index ["user_id"], name: "index_spree_credit_cards_on_user_id"
   end
 
-  create_table "spree_customer_returns", force: :cascade do |t|
+  create_table "spree_customer_returns", id: :serial, force: :cascade do |t|
     t.string "number"
     t.integer "stock_location_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
   end
 
-  create_table "spree_inventory_units", force: :cascade do |t|
+  create_table "spree_inventory_units", id: :serial, force: :cascade do |t|
     t.string "state"
     t.integer "variant_id"
     t.integer "shipment_id"
@@ -192,23 +207,25 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.boolean "pending", default: true
     t.integer "line_item_id"
     t.integer "carton_id"
+    t.string "sample_indicator_id"
     t.index ["carton_id"], name: "index_spree_inventory_units_on_carton_id"
     t.index ["line_item_id"], name: "index_spree_inventory_units_on_line_item_id"
     t.index ["shipment_id"], name: "index_inventory_units_on_shipment_id"
     t.index ["variant_id"], name: "index_inventory_units_on_variant_id"
   end
 
-  create_table "spree_line_item_actions", force: :cascade do |t|
+  create_table "spree_line_item_actions", id: :serial, force: :cascade do |t|
     t.integer "line_item_id", null: false
     t.integer "action_id", null: false
     t.integer "quantity", default: 0
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["action_id"], name: "index_spree_line_item_actions_on_action_id"
     t.index ["line_item_id"], name: "index_spree_line_item_actions_on_line_item_id"
   end
 
-  create_table "spree_line_items", force: :cascade do |t|
+  create_table "spree_line_items", id: :serial, force: :cascade do |t|
     t.integer "variant_id"
     t.integer "order_id"
     t.integer "quantity", null: false
@@ -221,62 +238,69 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.decimal "additional_tax_total", precision: 10, scale: 2, default: "0.0"
     t.decimal "promo_total", precision: 10, scale: 2, default: "0.0"
     t.decimal "included_tax_total", precision: 10, scale: 2, default: "0.0", null: false
+    t.string "sample_indicator_id"
     t.index ["order_id"], name: "index_spree_line_items_on_order_id"
     t.index ["variant_id"], name: "index_spree_line_items_on_variant_id"
   end
 
-  create_table "spree_log_entries", force: :cascade do |t|
+  create_table "spree_log_entries", id: :serial, force: :cascade do |t|
     t.string "source_type"
     t.integer "source_id"
     t.text "details"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["source_id", "source_type"], name: "index_spree_log_entries_on_source_id_and_source_type"
   end
 
-  create_table "spree_option_type_prototypes", force: :cascade do |t|
+  create_table "spree_option_type_prototypes", id: :serial, force: :cascade do |t|
     t.integer "prototype_id"
     t.integer "option_type_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
   end
 
-  create_table "spree_option_types", force: :cascade do |t|
+  create_table "spree_option_types", id: :serial, force: :cascade do |t|
     t.string "name", limit: 100
     t.string "presentation", limit: 100
     t.integer "position", default: 0, null: false
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["position"], name: "index_spree_option_types_on_position"
   end
 
-  create_table "spree_option_values", force: :cascade do |t|
+  create_table "spree_option_values", id: :serial, force: :cascade do |t|
     t.integer "position"
     t.string "name"
     t.string "presentation"
     t.integer "option_type_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["option_type_id"], name: "index_spree_option_values_on_option_type_id"
     t.index ["position"], name: "index_spree_option_values_on_position"
   end
 
-  create_table "spree_option_values_variants", force: :cascade do |t|
+  create_table "spree_option_values_variants", id: :serial, force: :cascade do |t|
     t.integer "variant_id"
     t.integer "option_value_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["variant_id", "option_value_id"], name: "index_option_values_variants_on_variant_id_and_option_value_id"
     t.index ["variant_id"], name: "index_spree_option_values_variants_on_variant_id"
   end
 
-  create_table "spree_order_mutexes", force: :cascade do |t|
+  create_table "spree_order_mutexes", id: :serial, force: :cascade do |t|
     t.integer "order_id", null: false
     t.datetime "created_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["order_id"], name: "index_spree_order_mutexes_on_order_id", unique: true
   end
 
-  create_table "spree_orders", force: :cascade do |t|
+  create_table "spree_orders", id: :serial, force: :cascade do |t|
     t.string "number", limit: 32
     t.decimal "item_total", precision: 10, scale: 2, default: "0.0", null: false
     t.decimal "total", precision: 10, scale: 2, default: "0.0", null: false
@@ -311,6 +335,7 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.integer "store_id"
     t.string "approver_name"
     t.boolean "frontend_viewable", default: true, null: false
+    t.string "sample_indicator_id"
     t.index ["approver_id"], name: "index_spree_orders_on_approver_id"
     t.index ["bill_address_id"], name: "index_spree_orders_on_bill_address_id"
     t.index ["completed_at"], name: "index_spree_orders_on_completed_at"
@@ -322,25 +347,27 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.index ["user_id"], name: "index_spree_orders_on_user_id"
   end
 
-  create_table "spree_orders_promotions", force: :cascade do |t|
+  create_table "spree_orders_promotions", id: :serial, force: :cascade do |t|
     t.integer "order_id"
     t.integer "promotion_id"
     t.integer "promotion_code_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["order_id", "promotion_id"], name: "index_spree_orders_promotions_on_order_id_and_promotion_id"
     t.index ["promotion_code_id"], name: "index_spree_orders_promotions_on_promotion_code_id"
   end
 
-  create_table "spree_payment_capture_events", force: :cascade do |t|
+  create_table "spree_payment_capture_events", id: :serial, force: :cascade do |t|
     t.decimal "amount", precision: 10, scale: 2, default: "0.0"
     t.integer "payment_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["payment_id"], name: "index_spree_payment_capture_events_on_payment_id"
   end
 
-  create_table "spree_payment_methods", force: :cascade do |t|
+  create_table "spree_payment_methods", id: :serial, force: :cascade do |t|
     t.string "type"
     t.string "name"
     t.text "description"
@@ -354,10 +381,11 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.integer "position", default: 0
     t.boolean "available_to_users", default: true
     t.boolean "available_to_admin", default: true
+    t.string "sample_indicator_id"
     t.index ["id", "type"], name: "index_spree_payment_methods_on_id_and_type"
   end
 
-  create_table "spree_payments", force: :cascade do |t|
+  create_table "spree_payments", id: :serial, force: :cascade do |t|
     t.decimal "amount", precision: 10, scale: 2, default: "0.0", null: false
     t.integer "order_id"
     t.string "source_type"
@@ -371,21 +399,23 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.string "number"
     t.string "cvv_response_code"
     t.string "cvv_response_message"
+    t.string "sample_indicator_id"
     t.index ["number"], name: "index_spree_payments_on_number", unique: true
     t.index ["order_id"], name: "index_spree_payments_on_order_id"
     t.index ["payment_method_id"], name: "index_spree_payments_on_payment_method_id"
     t.index ["source_id", "source_type"], name: "index_spree_payments_on_source_id_and_source_type"
   end
 
-  create_table "spree_preferences", force: :cascade do |t|
+  create_table "spree_preferences", id: :serial, force: :cascade do |t|
     t.text "value"
     t.string "key"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["key"], name: "index_spree_preferences_on_key", unique: true
   end
 
-  create_table "spree_prices", force: :cascade do |t|
+  create_table "spree_prices", id: :serial, force: :cascade do |t|
     t.integer "variant_id", null: false
     t.decimal "amount", precision: 10, scale: 2
     t.string "currency"
@@ -393,43 +423,47 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.string "country_iso", limit: 2
+    t.string "sample_indicator_id"
     t.index ["country_iso"], name: "index_spree_prices_on_country_iso"
     t.index ["variant_id", "currency"], name: "index_spree_prices_on_variant_id_and_currency"
   end
 
-  create_table "spree_product_option_types", force: :cascade do |t|
+  create_table "spree_product_option_types", id: :serial, force: :cascade do |t|
     t.integer "position"
     t.integer "product_id"
     t.integer "option_type_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["option_type_id"], name: "index_spree_product_option_types_on_option_type_id"
     t.index ["position"], name: "index_spree_product_option_types_on_position"
     t.index ["product_id"], name: "index_spree_product_option_types_on_product_id"
   end
 
-  create_table "spree_product_promotion_rules", force: :cascade do |t|
+  create_table "spree_product_promotion_rules", id: :serial, force: :cascade do |t|
     t.integer "product_id"
     t.integer "promotion_rule_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["product_id"], name: "index_products_promotion_rules_on_product_id"
     t.index ["promotion_rule_id"], name: "index_products_promotion_rules_on_promotion_rule_id"
   end
 
-  create_table "spree_product_properties", force: :cascade do |t|
+  create_table "spree_product_properties", id: :serial, force: :cascade do |t|
     t.string "value"
     t.integer "product_id"
     t.integer "property_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.integer "position", default: 0
+    t.string "sample_indicator_id"
     t.index ["position"], name: "index_spree_product_properties_on_position"
     t.index ["product_id"], name: "index_product_properties_on_product_id"
     t.index ["property_id"], name: "index_spree_product_properties_on_property_id"
   end
 
-  create_table "spree_products", force: :cascade do |t|
+  create_table "spree_products", id: :serial, force: :cascade do |t|
     t.string "name", default: "", null: false
     t.text "description"
     t.datetime "available_on"
@@ -443,34 +477,37 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "updated_at", precision: 6
     t.boolean "promotionable", default: true
     t.string "meta_title"
+    t.string "sample_indicator_id"
     t.index ["available_on"], name: "index_spree_products_on_available_on"
     t.index ["deleted_at"], name: "index_spree_products_on_deleted_at"
     t.index ["name"], name: "index_spree_products_on_name"
     t.index ["slug"], name: "index_spree_products_on_slug", unique: true
   end
 
-  create_table "spree_products_taxons", force: :cascade do |t|
+  create_table "spree_products_taxons", id: :serial, force: :cascade do |t|
     t.integer "product_id"
     t.integer "taxon_id"
     t.integer "position"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["position"], name: "index_spree_products_taxons_on_position"
     t.index ["product_id"], name: "index_spree_products_taxons_on_product_id"
     t.index ["taxon_id"], name: "index_spree_products_taxons_on_taxon_id"
   end
 
-  create_table "spree_promotion_action_line_items", force: :cascade do |t|
+  create_table "spree_promotion_action_line_items", id: :serial, force: :cascade do |t|
     t.integer "promotion_action_id"
     t.integer "variant_id"
     t.integer "quantity", default: 1
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["promotion_action_id"], name: "index_spree_promotion_action_line_items_on_promotion_action_id"
     t.index ["variant_id"], name: "index_spree_promotion_action_line_items_on_variant_id"
   end
 
-  create_table "spree_promotion_actions", force: :cascade do |t|
+  create_table "spree_promotion_actions", id: :serial, force: :cascade do |t|
     t.integer "promotion_id"
     t.integer "position"
     t.string "type"
@@ -478,19 +515,21 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.text "preferences"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["deleted_at"], name: "index_spree_promotion_actions_on_deleted_at"
     t.index ["id", "type"], name: "index_spree_promotion_actions_on_id_and_type"
     t.index ["promotion_id"], name: "index_spree_promotion_actions_on_promotion_id"
   end
 
-  create_table "spree_promotion_categories", force: :cascade do |t|
+  create_table "spree_promotion_categories", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.string "code"
+    t.string "sample_indicator_id"
   end
 
-  create_table "spree_promotion_code_batches", force: :cascade do |t|
+  create_table "spree_promotion_code_batches", id: :serial, force: :cascade do |t|
     t.integer "promotion_id", null: false
     t.string "base_code", null: false
     t.integer "number_of_codes", null: false
@@ -500,30 +539,33 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "join_characters", default: "_", null: false
+    t.string "sample_indicator_id"
     t.index ["promotion_id"], name: "index_spree_promotion_code_batches_on_promotion_id"
   end
 
-  create_table "spree_promotion_codes", force: :cascade do |t|
+  create_table "spree_promotion_codes", id: :serial, force: :cascade do |t|
     t.integer "promotion_id", null: false
     t.string "value", null: false
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.integer "promotion_code_batch_id"
+    t.string "sample_indicator_id"
     t.index ["promotion_code_batch_id"], name: "index_spree_promotion_codes_on_promotion_code_batch_id"
     t.index ["promotion_id"], name: "index_spree_promotion_codes_on_promotion_id"
     t.index ["value"], name: "index_spree_promotion_codes_on_value", unique: true
   end
 
-  create_table "spree_promotion_rule_taxons", force: :cascade do |t|
+  create_table "spree_promotion_rule_taxons", id: :serial, force: :cascade do |t|
     t.integer "taxon_id"
     t.integer "promotion_rule_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["promotion_rule_id"], name: "index_spree_promotion_rule_taxons_on_promotion_rule_id"
     t.index ["taxon_id"], name: "index_spree_promotion_rule_taxons_on_taxon_id"
   end
 
-  create_table "spree_promotion_rules", force: :cascade do |t|
+  create_table "spree_promotion_rules", id: :serial, force: :cascade do |t|
     t.integer "promotion_id"
     t.integer "product_group_id"
     t.string "type"
@@ -531,29 +573,32 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "updated_at", precision: 6
     t.string "code"
     t.text "preferences"
+    t.string "sample_indicator_id"
     t.index ["product_group_id"], name: "index_promotion_rules_on_product_group_id"
     t.index ["promotion_id"], name: "index_spree_promotion_rules_on_promotion_id"
   end
 
   create_table "spree_promotion_rules_stores", force: :cascade do |t|
-    t.integer "store_id", null: false
-    t.integer "promotion_rule_id", null: false
+    t.bigint "store_id", null: false
+    t.bigint "promotion_rule_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "sample_indicator_id"
     t.index ["promotion_rule_id"], name: "index_spree_promotion_rules_stores_on_promotion_rule_id"
     t.index ["store_id"], name: "index_spree_promotion_rules_stores_on_store_id"
   end
 
-  create_table "spree_promotion_rules_users", force: :cascade do |t|
+  create_table "spree_promotion_rules_users", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "promotion_rule_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["promotion_rule_id"], name: "index_promotion_rules_users_on_promotion_rule_id"
     t.index ["user_id"], name: "index_promotion_rules_users_on_user_id"
   end
 
-  create_table "spree_promotions", force: :cascade do |t|
+  create_table "spree_promotions", id: :serial, force: :cascade do |t|
     t.string "description"
     t.datetime "expires_at"
     t.datetime "starts_at"
@@ -568,6 +613,7 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.integer "promotion_category_id"
     t.integer "per_code_usage_limit"
     t.boolean "apply_automatically", default: false
+    t.string "sample_indicator_id"
     t.index ["advertise"], name: "index_spree_promotions_on_advertise"
     t.index ["apply_automatically"], name: "index_spree_promotions_on_apply_automatically"
     t.index ["expires_at"], name: "index_spree_promotions_on_expires_at"
@@ -576,45 +622,50 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.index ["starts_at"], name: "index_spree_promotions_on_starts_at"
   end
 
-  create_table "spree_properties", force: :cascade do |t|
+  create_table "spree_properties", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "presentation", null: false
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
   end
 
-  create_table "spree_property_prototypes", force: :cascade do |t|
+  create_table "spree_property_prototypes", id: :serial, force: :cascade do |t|
     t.integer "prototype_id"
     t.integer "property_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
   end
 
-  create_table "spree_prototype_taxons", force: :cascade do |t|
+  create_table "spree_prototype_taxons", id: :serial, force: :cascade do |t|
     t.integer "taxon_id"
     t.integer "prototype_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["prototype_id"], name: "index_spree_prototype_taxons_on_prototype_id"
     t.index ["taxon_id"], name: "index_spree_prototype_taxons_on_taxon_id"
   end
 
-  create_table "spree_prototypes", force: :cascade do |t|
+  create_table "spree_prototypes", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
   end
 
-  create_table "spree_refund_reasons", force: :cascade do |t|
+  create_table "spree_refund_reasons", id: :serial, force: :cascade do |t|
     t.string "name"
     t.boolean "active", default: true
     t.boolean "mutable", default: true
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.string "code"
+    t.string "sample_indicator_id"
   end
 
-  create_table "spree_refunds", force: :cascade do |t|
+  create_table "spree_refunds", id: :serial, force: :cascade do |t|
     t.integer "payment_id"
     t.decimal "amount", precision: 10, scale: 2, default: "0.0", null: false
     t.string "transaction_id"
@@ -622,31 +673,34 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "updated_at", precision: 6
     t.integer "refund_reason_id"
     t.integer "reimbursement_id"
+    t.string "sample_indicator_id"
     t.index ["payment_id"], name: "index_spree_refunds_on_payment_id"
     t.index ["refund_reason_id"], name: "index_refunds_on_refund_reason_id"
     t.index ["reimbursement_id"], name: "index_spree_refunds_on_reimbursement_id"
   end
 
-  create_table "spree_reimbursement_credits", force: :cascade do |t|
+  create_table "spree_reimbursement_credits", id: :serial, force: :cascade do |t|
     t.decimal "amount", precision: 10, scale: 2, default: "0.0", null: false
     t.integer "reimbursement_id"
     t.integer "creditable_id"
     t.string "creditable_type"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
   end
 
-  create_table "spree_reimbursement_types", force: :cascade do |t|
+  create_table "spree_reimbursement_types", id: :serial, force: :cascade do |t|
     t.string "name"
     t.boolean "active", default: true
     t.boolean "mutable", default: true
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.string "type"
+    t.string "sample_indicator_id"
     t.index ["type"], name: "index_spree_reimbursement_types_on_type"
   end
 
-  create_table "spree_reimbursements", force: :cascade do |t|
+  create_table "spree_reimbursements", id: :serial, force: :cascade do |t|
     t.string "number"
     t.string "reimbursement_status"
     t.integer "customer_return_id"
@@ -654,11 +708,12 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.decimal "total", precision: 10, scale: 2
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["customer_return_id"], name: "index_spree_reimbursements_on_customer_return_id"
     t.index ["order_id"], name: "index_spree_reimbursements_on_order_id"
   end
 
-  create_table "spree_return_authorizations", force: :cascade do |t|
+  create_table "spree_return_authorizations", id: :serial, force: :cascade do |t|
     t.string "number"
     t.string "state"
     t.integer "order_id"
@@ -667,10 +722,11 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "updated_at", precision: 6
     t.integer "stock_location_id"
     t.integer "return_reason_id"
+    t.string "sample_indicator_id"
     t.index ["return_reason_id"], name: "index_return_authorizations_on_return_authorization_reason_id"
   end
 
-  create_table "spree_return_items", force: :cascade do |t|
+  create_table "spree_return_items", id: :serial, force: :cascade do |t|
     t.integer "return_authorization_id"
     t.integer "inventory_unit_id"
     t.integer "exchange_variant_id"
@@ -689,36 +745,40 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.integer "override_reimbursement_type_id"
     t.boolean "resellable", default: true, null: false
     t.integer "return_reason_id"
+    t.string "sample_indicator_id"
     t.index ["customer_return_id"], name: "index_return_items_on_customer_return_id"
     t.index ["exchange_inventory_unit_id"], name: "index_spree_return_items_on_exchange_inventory_unit_id"
   end
 
-  create_table "spree_return_reasons", force: :cascade do |t|
+  create_table "spree_return_reasons", id: :serial, force: :cascade do |t|
     t.string "name"
     t.boolean "active", default: true
     t.boolean "mutable", default: true
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
   end
 
-  create_table "spree_roles", force: :cascade do |t|
+  create_table "spree_roles", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["name"], name: "index_spree_roles_on_name", unique: true
   end
 
-  create_table "spree_roles_users", force: :cascade do |t|
+  create_table "spree_roles_users", id: :serial, force: :cascade do |t|
     t.integer "role_id"
     t.integer "user_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["role_id"], name: "index_spree_roles_users_on_role_id"
     t.index ["user_id", "role_id"], name: "index_spree_roles_users_on_user_id_and_role_id", unique: true
     t.index ["user_id"], name: "index_spree_roles_users_on_user_id"
   end
 
-  create_table "spree_shipments", force: :cascade do |t|
+  create_table "spree_shipments", id: :serial, force: :cascade do |t|
     t.string "tracking"
     t.string "number"
     t.decimal "cost", precision: 10, scale: 2, default: "0.0"
@@ -733,44 +793,49 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.decimal "additional_tax_total", precision: 10, scale: 2, default: "0.0"
     t.decimal "promo_total", precision: 10, scale: 2, default: "0.0"
     t.decimal "included_tax_total", precision: 10, scale: 2, default: "0.0", null: false
+    t.string "sample_indicator_id"
     t.index ["deprecated_address_id"], name: "index_spree_shipments_on_deprecated_address_id"
     t.index ["number"], name: "index_shipments_on_number"
     t.index ["order_id"], name: "index_spree_shipments_on_order_id"
     t.index ["stock_location_id"], name: "index_spree_shipments_on_stock_location_id"
   end
 
-  create_table "spree_shipping_categories", force: :cascade do |t|
+  create_table "spree_shipping_categories", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
   end
 
-  create_table "spree_shipping_method_categories", force: :cascade do |t|
+  create_table "spree_shipping_method_categories", id: :serial, force: :cascade do |t|
     t.integer "shipping_method_id", null: false
     t.integer "shipping_category_id", null: false
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["shipping_category_id", "shipping_method_id"], name: "unique_spree_shipping_method_categories", unique: true
     t.index ["shipping_method_id"], name: "index_spree_shipping_method_categories_on_shipping_method_id"
   end
 
-  create_table "spree_shipping_method_stock_locations", force: :cascade do |t|
+  create_table "spree_shipping_method_stock_locations", id: :serial, force: :cascade do |t|
     t.integer "shipping_method_id"
     t.integer "stock_location_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["shipping_method_id"], name: "shipping_method_id_spree_sm_sl"
     t.index ["stock_location_id"], name: "sstock_location_id_spree_sm_sl"
   end
 
-  create_table "spree_shipping_method_zones", force: :cascade do |t|
+  create_table "spree_shipping_method_zones", id: :serial, force: :cascade do |t|
     t.integer "shipping_method_id"
     t.integer "zone_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
   end
 
-  create_table "spree_shipping_methods", force: :cascade do |t|
+  create_table "spree_shipping_methods", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6
@@ -783,20 +848,22 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.string "carrier"
     t.string "service_level"
     t.boolean "available_to_users", default: true
+    t.string "sample_indicator_id"
     t.index ["tax_category_id"], name: "index_spree_shipping_methods_on_tax_category_id"
   end
 
-  create_table "spree_shipping_rate_taxes", force: :cascade do |t|
+  create_table "spree_shipping_rate_taxes", id: :serial, force: :cascade do |t|
     t.decimal "amount", precision: 8, scale: 2, default: "0.0", null: false
     t.integer "tax_rate_id"
     t.integer "shipping_rate_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "sample_indicator_id"
     t.index ["shipping_rate_id"], name: "index_spree_shipping_rate_taxes_on_shipping_rate_id"
     t.index ["tax_rate_id"], name: "index_spree_shipping_rate_taxes_on_tax_rate_id"
   end
 
-  create_table "spree_shipping_rates", force: :cascade do |t|
+  create_table "spree_shipping_rates", id: :serial, force: :cascade do |t|
     t.integer "shipment_id"
     t.integer "shipping_method_id"
     t.boolean "selected", default: false
@@ -804,10 +871,11 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.integer "tax_rate_id"
+    t.string "sample_indicator_id"
     t.index ["shipment_id", "shipping_method_id"], name: "spree_shipping_rates_join_index", unique: true
   end
 
-  create_table "spree_state_changes", force: :cascade do |t|
+  create_table "spree_state_changes", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "previous_state"
     t.integer "stateful_id"
@@ -816,20 +884,22 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.string "next_state"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["stateful_id", "stateful_type"], name: "index_spree_state_changes_on_stateful_id_and_stateful_type"
     t.index ["user_id"], name: "index_spree_state_changes_on_user_id"
   end
 
-  create_table "spree_states", force: :cascade do |t|
+  create_table "spree_states", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "abbr"
     t.integer "country_id"
     t.datetime "updated_at", precision: 6
     t.datetime "created_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["country_id"], name: "index_spree_states_on_country_id"
   end
 
-  create_table "spree_stock_items", force: :cascade do |t|
+  create_table "spree_stock_items", id: :serial, force: :cascade do |t|
     t.integer "stock_location_id"
     t.integer "variant_id"
     t.integer "count_on_hand", default: 0, null: false
@@ -837,13 +907,14 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "updated_at", precision: 6
     t.boolean "backorderable", default: false
     t.datetime "deleted_at"
+    t.string "sample_indicator_id"
     t.index ["deleted_at"], name: "index_spree_stock_items_on_deleted_at"
     t.index ["stock_location_id", "variant_id"], name: "stock_item_by_loc_and_var_id"
     t.index ["stock_location_id"], name: "index_spree_stock_items_on_stock_location_id"
-    t.index ["variant_id", "stock_location_id"], name: "index_spree_stock_items_on_variant_id_and_stock_location_id", unique: true, where: "deleted_at is null"
+    t.index ["variant_id", "stock_location_id"], name: "index_spree_stock_items_on_variant_id_and_stock_location_id", unique: true, where: "(deleted_at IS NULL)"
   end
 
-  create_table "spree_stock_locations", force: :cascade do |t|
+  create_table "spree_stock_locations", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
@@ -865,11 +936,12 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.boolean "fulfillable", default: true, null: false
     t.string "code"
     t.boolean "check_stock_on_transfer", default: true
+    t.string "sample_indicator_id"
     t.index ["country_id"], name: "index_spree_stock_locations_on_country_id"
     t.index ["state_id"], name: "index_spree_stock_locations_on_state_id"
   end
 
-  create_table "spree_stock_movements", force: :cascade do |t|
+  create_table "spree_stock_movements", id: :serial, force: :cascade do |t|
     t.integer "stock_item_id"
     t.integer "quantity", default: 0
     t.string "action"
@@ -877,16 +949,18 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "originator_type"
     t.integer "originator_id"
+    t.string "sample_indicator_id"
     t.index ["stock_item_id"], name: "index_spree_stock_movements_on_stock_item_id"
   end
 
-  create_table "spree_store_credit_categories", force: :cascade do |t|
+  create_table "spree_store_credit_categories", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
   end
 
-  create_table "spree_store_credit_events", force: :cascade do |t|
+  create_table "spree_store_credit_events", id: :serial, force: :cascade do |t|
     t.integer "store_credit_id", null: false
     t.string "action", null: false
     t.decimal "amount", precision: 8, scale: 2
@@ -899,6 +973,7 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "updated_at", precision: 6
     t.decimal "amount_remaining", precision: 8, scale: 2
     t.integer "store_credit_reason_id"
+    t.string "sample_indicator_id"
     t.index ["deleted_at"], name: "index_spree_store_credit_events_on_deleted_at"
     t.index ["store_credit_id"], name: "index_spree_store_credit_events_on_store_credit_id"
   end
@@ -908,17 +983,19 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.boolean "active", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "sample_indicator_id"
   end
 
-  create_table "spree_store_credit_types", force: :cascade do |t|
+  create_table "spree_store_credit_types", id: :serial, force: :cascade do |t|
     t.string "name"
     t.integer "priority"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["priority"], name: "index_spree_store_credit_types_on_priority"
   end
 
-  create_table "spree_store_credits", force: :cascade do |t|
+  create_table "spree_store_credits", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "category_id"
     t.integer "created_by_id"
@@ -932,30 +1009,33 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "updated_at", precision: 6
     t.integer "type_id"
     t.datetime "invalidated_at"
+    t.string "sample_indicator_id"
     t.index ["deleted_at"], name: "index_spree_store_credits_on_deleted_at"
     t.index ["type_id"], name: "index_spree_store_credits_on_type_id"
     t.index ["user_id"], name: "index_spree_store_credits_on_user_id"
   end
 
-  create_table "spree_store_payment_methods", force: :cascade do |t|
+  create_table "spree_store_payment_methods", id: :serial, force: :cascade do |t|
     t.integer "store_id", null: false
     t.integer "payment_method_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "sample_indicator_id"
     t.index ["payment_method_id"], name: "index_spree_store_payment_methods_on_payment_method_id"
     t.index ["store_id"], name: "index_spree_store_payment_methods_on_store_id"
   end
 
   create_table "spree_store_shipping_methods", force: :cascade do |t|
-    t.integer "store_id", null: false
-    t.integer "shipping_method_id", null: false
+    t.bigint "store_id", null: false
+    t.bigint "shipping_method_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "sample_indicator_id"
     t.index ["shipping_method_id"], name: "index_spree_store_shipping_methods_on_shipping_method_id"
     t.index ["store_id"], name: "index_spree_store_shipping_methods_on_store_id"
   end
 
-  create_table "spree_stores", force: :cascade do |t|
+  create_table "spree_stores", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "url"
     t.text "meta_description"
@@ -969,11 +1049,12 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "updated_at", precision: 6
     t.string "cart_tax_country_iso"
     t.string "available_locales"
+    t.string "sample_indicator_id"
     t.index ["code"], name: "index_spree_stores_on_code"
     t.index ["default"], name: "index_spree_stores_on_default"
   end
 
-  create_table "spree_tax_categories", force: :cascade do |t|
+  create_table "spree_tax_categories", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "description"
     t.boolean "is_default", default: false
@@ -981,16 +1062,18 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.string "tax_code"
+    t.string "sample_indicator_id"
   end
 
-  create_table "spree_tax_rate_tax_categories", force: :cascade do |t|
+  create_table "spree_tax_rate_tax_categories", id: :serial, force: :cascade do |t|
     t.integer "tax_category_id", null: false
     t.integer "tax_rate_id", null: false
+    t.string "sample_indicator_id"
     t.index ["tax_category_id"], name: "index_spree_tax_rate_tax_categories_on_tax_category_id"
     t.index ["tax_rate_id"], name: "index_spree_tax_rate_tax_categories_on_tax_rate_id"
   end
 
-  create_table "spree_tax_rates", force: :cascade do |t|
+  create_table "spree_tax_rates", id: :serial, force: :cascade do |t|
     t.decimal "amount", precision: 8, scale: 5
     t.integer "zone_id"
     t.boolean "included_in_price", default: false
@@ -1001,19 +1084,21 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.datetime "deleted_at"
     t.datetime "starts_at"
     t.datetime "expires_at"
+    t.string "sample_indicator_id"
     t.index ["deleted_at"], name: "index_spree_tax_rates_on_deleted_at"
     t.index ["zone_id"], name: "index_spree_tax_rates_on_zone_id"
   end
 
-  create_table "spree_taxonomies", force: :cascade do |t|
+  create_table "spree_taxonomies", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.integer "position", default: 0
+    t.string "sample_indicator_id"
     t.index ["position"], name: "index_spree_taxonomies_on_position"
   end
 
-  create_table "spree_taxons", force: :cascade do |t|
+  create_table "spree_taxons", id: :serial, force: :cascade do |t|
     t.integer "parent_id"
     t.integer "position", default: 0
     t.string "name", null: false
@@ -1032,6 +1117,7 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.string "meta_description"
     t.string "meta_keywords"
     t.integer "depth"
+    t.string "sample_indicator_id"
     t.index ["lft"], name: "index_spree_taxons_on_lft"
     t.index ["parent_id"], name: "index_taxons_on_parent_id"
     t.index ["permalink"], name: "index_taxons_on_permalink"
@@ -1040,36 +1126,39 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.index ["taxonomy_id"], name: "index_taxons_on_taxonomy_id"
   end
 
-  create_table "spree_unit_cancels", force: :cascade do |t|
+  create_table "spree_unit_cancels", id: :serial, force: :cascade do |t|
     t.integer "inventory_unit_id", null: false
     t.string "reason"
     t.string "created_by"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["inventory_unit_id"], name: "index_spree_unit_cancels_on_inventory_unit_id"
   end
 
-  create_table "spree_user_addresses", force: :cascade do |t|
+  create_table "spree_user_addresses", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "address_id", null: false
     t.boolean "default", default: false
     t.boolean "archived", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "sample_indicator_id"
     t.index ["address_id"], name: "index_spree_user_addresses_on_address_id"
     t.index ["user_id", "address_id"], name: "index_spree_user_addresses_on_user_id_and_address_id", unique: true
     t.index ["user_id"], name: "index_spree_user_addresses_on_user_id"
   end
 
-  create_table "spree_user_stock_locations", force: :cascade do |t|
+  create_table "spree_user_stock_locations", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "stock_location_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["user_id"], name: "index_spree_user_stock_locations_on_user_id"
   end
 
-  create_table "spree_users", force: :cascade do |t|
+  create_table "spree_users", id: :serial, force: :cascade do |t|
     t.string "encrypted_password", limit: 128
     t.string "password_salt", limit: 128
     t.string "email"
@@ -1099,38 +1188,42 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
+    t.string "sample_indicator_id"
     t.index ["deleted_at"], name: "index_spree_users_on_deleted_at"
     t.index ["email"], name: "email_idx_unique", unique: true
     t.index ["spree_api_key"], name: "index_spree_users_on_spree_api_key"
   end
 
-  create_table "spree_variant_property_rule_conditions", force: :cascade do |t|
+  create_table "spree_variant_property_rule_conditions", id: :serial, force: :cascade do |t|
     t.integer "option_value_id"
     t.integer "variant_property_rule_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "sample_indicator_id"
     t.index ["variant_property_rule_id", "option_value_id"], name: "index_spree_variant_prop_rule_conditions_on_rule_and_optval"
   end
 
-  create_table "spree_variant_property_rule_values", force: :cascade do |t|
+  create_table "spree_variant_property_rule_values", id: :serial, force: :cascade do |t|
     t.text "value"
     t.integer "position", default: 0
     t.integer "property_id"
     t.integer "variant_property_rule_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["property_id"], name: "index_spree_variant_property_rule_values_on_property_id"
     t.index ["variant_property_rule_id"], name: "index_spree_variant_property_rule_values_on_rule"
   end
 
-  create_table "spree_variant_property_rules", force: :cascade do |t|
+  create_table "spree_variant_property_rules", id: :serial, force: :cascade do |t|
     t.integer "product_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "sample_indicator_id"
     t.index ["product_id"], name: "index_spree_variant_property_rules_on_product_id"
   end
 
-  create_table "spree_variants", force: :cascade do |t|
+  create_table "spree_variants", id: :serial, force: :cascade do |t|
     t.string "sku", default: "", null: false
     t.decimal "weight", precision: 8, scale: 2, default: "0.0"
     t.decimal "height", precision: 8, scale: 2
@@ -1146,6 +1239,7 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.integer "tax_category_id"
     t.datetime "updated_at", precision: 6
     t.datetime "created_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["position"], name: "index_spree_variants_on_position"
     t.index ["product_id"], name: "index_spree_variants_on_product_id"
     t.index ["sku"], name: "index_spree_variants_on_sku"
@@ -1153,33 +1247,42 @@ ActiveRecord::Schema.define(version: 2020_03_14_092732) do
     t.index ["track_inventory"], name: "index_spree_variants_on_track_inventory"
   end
 
-  create_table "spree_wallet_payment_sources", force: :cascade do |t|
+  create_table "spree_wallet_payment_sources", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "payment_source_type", null: false
     t.integer "payment_source_id", null: false
     t.boolean "default", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "sample_indicator_id"
     t.index ["user_id", "payment_source_id", "payment_source_type"], name: "index_spree_wallet_payment_sources_on_source_and_user", unique: true
     t.index ["user_id"], name: "index_spree_wallet_payment_sources_on_user_id"
   end
 
-  create_table "spree_zone_members", force: :cascade do |t|
+  create_table "spree_zone_members", id: :serial, force: :cascade do |t|
     t.string "zoneable_type"
     t.integer "zoneable_id"
     t.integer "zone_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
     t.index ["zone_id"], name: "index_spree_zone_members_on_zone_id"
     t.index ["zoneable_id", "zoneable_type"], name: "index_spree_zone_members_on_zoneable_id_and_zoneable_type"
   end
 
-  create_table "spree_zones", force: :cascade do |t|
+  create_table "spree_zones", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "description"
     t.integer "zone_members_count", default: 0
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.string "sample_indicator_id"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "spree_promotion_code_batches", "spree_promotions", column: "promotion_id"
+  add_foreign_key "spree_promotion_codes", "spree_promotion_code_batches", column: "promotion_code_batch_id"
+  add_foreign_key "spree_tax_rate_tax_categories", "spree_tax_categories", column: "tax_category_id"
+  add_foreign_key "spree_tax_rate_tax_categories", "spree_tax_rates", column: "tax_rate_id"
+  add_foreign_key "spree_wallet_payment_sources", "spree_users", column: "user_id"
 end


### PR DESCRIPTION
Allows you to save and edit your saved records on backend and API.
Other people cannot see what you've created - only you can. Conversely
you can't see what others have created. You can also see the sample
data, but you cannot edit or delete it, since that would make those
changes visible by everyone. I'm still trying to work out how to
allow editing of those objects...